### PR TITLE
Extract `aetheroom.club` import code to separate module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ flask_session/1074228e7055acfb7de9d07a471d0b92
 .gitignore
 flask_session/2029240f6d1128be89ddc32729463129
 flask_session
+
+# virtualenvs
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Uninstall
 flask_session
 accelerate-disk-cache
 .ipynb_checkpoints
+unit_test_report.html
 
 # Temporary until HF port
 !models/RWKV-v4
@@ -36,8 +37,9 @@ models/RWKV-v4/20B_tokenizer.json
 models/RWKV-v4/src/__pycache__
 models/RWKV-v4/models
 
-# Ignore PyCharm project files.
+# Ignore PyCharm, VSCode project files.
 .idea
+.vscode
 
 # Ignore compiled Python files.
 *.pyc

--- a/aiserver.py
+++ b/aiserver.py
@@ -422,7 +422,7 @@ class ImportBuffer:
             status = err.status_code
             print(f"[import] Got {status} on request to club :^(")
             message = f"Club responded with {status}"
-            if status == "404":
+            if status == 404:
                 message = f"Prompt not found for ID {club_id}"
             show_error_notification("Error loading prompt", message)
             return

--- a/importers/aetherroom.py
+++ b/importers/aetherroom.py
@@ -16,7 +16,7 @@ class ImportData:
 
 
 class RequestFailed(Exception):
-    def __init__(self, status_code: str) -> None:
+    def __init__(self, status_code: int) -> None:
         self.status_code = status_code
         super().__init__()
 

--- a/importers/aetherroom.py
+++ b/importers/aetherroom.py
@@ -1,0 +1,57 @@
+from dataclasses import dataclass
+import requests
+from typing import List
+
+BASE_URL = "https://aetherroom.club/api/"
+
+
+@dataclass
+class ImportData:
+    prompt: str
+    memory: str
+    authors_note: str
+    notes: str
+    title: str
+    world_infos: List[object]
+
+
+class RequestFailed(Exception):
+    def __init__(self, status_code: str) -> None:
+        self.status_code = status_code
+        super().__init__()
+
+
+def import_scenario(id: int) -> ImportData:
+    """
+    Fetches story info from the provided AetherRoom scenario ID.
+    """
+    # Maybe it is a better to parse the NAI Scenario (if available), it has more data
+    req = requests.get(f"{BASE_URL}{id}")
+    if not req.ok:
+        raise RequestFailed(req.status_code)
+
+    json = req.json()
+    prompt = json["promptContent"]
+    memory = json["memory"]
+    authors_note = json["authorsNote"]
+    notes = json["description"]
+    title = json.get("title", "Imported Story")
+
+    world_infos = []
+    for info in json["worldinfos"]:
+        world_infos.append(
+            {
+                "key_list": info["keysList"],
+                "keysecondary": [],
+                "content": info["entry"],
+                "comment": "",
+                "folder": info.get("folder", None),
+                "num": 0,
+                "init": True,
+                "selective": info.get("selective", False),
+                "constant": info.get("constant", False),
+                "uid": None,
+            }
+        )
+
+    return ImportData(prompt, memory, authors_note, notes, title, world_infos)

--- a/importers/aetherroom.py
+++ b/importers/aetherroom.py
@@ -38,7 +38,7 @@ def import_scenario(id: int) -> ImportData:
     title = json.get("title", "Imported Story")
 
     world_infos = []
-    for info in json["worldinfos"]:
+    for info in json["worldInfos"]:
         world_infos.append(
             {
                 "key_list": info["keysList"],

--- a/importers/test_aetherroom.py
+++ b/importers/test_aetherroom.py
@@ -21,7 +21,7 @@ def test_import_scenario_success(requests_mock: requests_mock.Mocker):
         "authorsNote": "authorsNote",
         "description": "description",
         "title": "title",
-        "worldinfos": [],
+        "worldInfos": [],
     }
     requests_mock.get("https://aetherroom.club/api/1", json=json)
 
@@ -37,7 +37,7 @@ def test_import_scenario_no_title(requests_mock: requests_mock.Mocker):
         "memory": "memory",
         "authorsNote": "authorsNote",
         "description": "description",
-        "worldinfos": [],
+        "worldInfos": [],
     }
     requests_mock.get("https://aetherroom.club/api/1", json=json)
 
@@ -53,7 +53,7 @@ def test_import_scenario_world_infos(requests_mock: requests_mock.Mocker):
         "memory": "memory",
         "authorsNote": "authorsNote",
         "description": "description",
-        "worldinfos": [
+        "worldInfos": [
             {
                 "entry": "Info 1",
                 "keysList": ["a", "b", "c"],
@@ -116,7 +116,7 @@ def test_import_scenario_world_info_missing_properties(
         "memory": "memory",
         "authorsNote": "authorsNote",
         "description": "description",
-        "worldinfos": [
+        "worldInfos": [
             {
                 "entry": "Info 1",
                 "keysList": ["a", "b", "c"],

--- a/importers/test_aetherroom.py
+++ b/importers/test_aetherroom.py
@@ -1,0 +1,149 @@
+import pytest
+import requests_mock
+
+from importers.aetherroom import (
+    ImportData,
+    RequestFailed,
+    import_scenario,
+)
+
+
+def test_import_scenario_http_error(requests_mock: requests_mock.mocker):
+    requests_mock.get("https://aetherroom.club/api/1", status_code=404)
+    with pytest.raises(RequestFailed):
+        import_scenario(1)
+
+
+def test_import_scenario_success(requests_mock: requests_mock.Mocker):
+    json = {
+        "promptContent": "promptContent",
+        "memory": "memory",
+        "authorsNote": "authorsNote",
+        "description": "description",
+        "title": "title",
+        "worldinfos": [],
+    }
+    requests_mock.get("https://aetherroom.club/api/1", json=json)
+
+    expected_import_data = ImportData(
+        "promptContent", "memory", "authorsNote", "description", "title", []
+    )
+    assert import_scenario(1) == expected_import_data
+
+
+def test_import_scenario_no_title(requests_mock: requests_mock.Mocker):
+    json = {
+        "promptContent": "promptContent",
+        "memory": "memory",
+        "authorsNote": "authorsNote",
+        "description": "description",
+        "worldinfos": [],
+    }
+    requests_mock.get("https://aetherroom.club/api/1", json=json)
+
+    expected_import_data = ImportData(
+        "promptContent", "memory", "authorsNote", "description", "Imported Story", []
+    )
+    assert import_scenario(1) == expected_import_data
+
+
+def test_import_scenario_world_infos(requests_mock: requests_mock.Mocker):
+    json = {
+        "promptContent": "promptContent",
+        "memory": "memory",
+        "authorsNote": "authorsNote",
+        "description": "description",
+        "worldinfos": [
+            {
+                "entry": "Info 1",
+                "keysList": ["a", "b", "c"],
+                "folder": "folder",
+                "selective": True,
+                "constant": True,
+            },
+            {
+                "entry": "Info 2",
+                "keysList": ["d", "e", "f"],
+                "folder": "folder 2",
+                "selective": True,
+                "constant": True,
+            },
+        ],
+    }
+    requests_mock.get("https://aetherroom.club/api/1", json=json)
+
+    expected_import_data = ImportData(
+        "promptContent",
+        "memory",
+        "authorsNote",
+        "description",
+        "Imported Story",
+        [
+            {
+                "content": "Info 1",
+                "key_list": ["a", "b", "c"],
+                "keysecondary": [],
+                "comment": "",
+                "num": 0,
+                "init": True,
+                "uid": None,
+                "folder": "folder",
+                "selective": True,
+                "constant": True,
+            },
+            {
+                "content": "Info 2",
+                "key_list": ["d", "e", "f"],
+                "keysecondary": [],
+                "comment": "",
+                "num": 0,
+                "init": True,
+                "uid": None,
+                "folder": "folder 2",
+                "selective": True,
+                "constant": True,
+            },
+        ],
+    )
+    assert import_scenario(1) == expected_import_data
+
+
+def test_import_scenario_world_info_missing_properties(
+    requests_mock: requests_mock.Mocker,
+):
+    json = {
+        "promptContent": "promptContent",
+        "memory": "memory",
+        "authorsNote": "authorsNote",
+        "description": "description",
+        "worldinfos": [
+            {
+                "entry": "Info 1",
+                "keysList": ["a", "b", "c"],
+            }
+        ],
+    }
+    requests_mock.get("https://aetherroom.club/api/1", json=json)
+
+    expected_import_data = ImportData(
+        "promptContent",
+        "memory",
+        "authorsNote",
+        "description",
+        "Imported Story",
+        [
+            {
+                "content": "Info 1",
+                "key_list": ["a", "b", "c"],
+                "keysecondary": [],
+                "comment": "",
+                "num": 0,
+                "init": True,
+                "uid": None,
+                "folder": None,
+                "selective": False,
+                "constant": False,
+            }
+        ],
+    )
+    assert import_scenario(1) == expected_import_data

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ dnspython==2.2.1
 lupa==1.10
 markdown
 bleach==4.1.0
+black
 sentencepiece
 protobuf
 accelerate
@@ -29,5 +30,10 @@ flask_compress
 ijson
 bitsandbytes
 ftfy
+py==1.11.0
 pydub
+pytest==7.2.2
+pytest-html==3.2.0
+pytest-metadata==2.0.4
+requests-mock==1.10.0
 safetensors

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ dnspython==2.2.1
 lupa==1.10
 markdown
 bleach==4.1.0
-black
 sentencepiece
 protobuf
 accelerate


### PR DESCRIPTION
## What

Moves `aetherroom.club` imports to a separate helper.

## Why

Need to chip away at `aiserver` somehow.

## Tests

- [x] unit tests
- [x] scenario import works in UI1
  - [x] world info loads 
- [x] scenario import works in UI2
  - [x] prompt placeholders load
  - [x] world info loads  