### PR TITLE
Accelerate offloading fixes

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -1528,6 +1528,7 @@ def general_startup(override_args=None):
             print(f"Allowed IPs: {allowed_ips}")
 
     if args.cpu:
+        os.environ['CUDA_VISIBLE_DEVICES'] = "None"
         koboldai_vars.use_colab_tpu = False
         koboldai_vars.hascuda = False
         koboldai_vars.usegpu = False

--- a/modeling/inference_models/hf_torch.py
+++ b/modeling/inference_models/hf_torch.py
@@ -121,6 +121,8 @@ class HFTorchInferenceModel(HFInferenceModel):
             return torch.float32
         elif utils.args.cpu:
             return torch.float32
+        elif not self.usegpu and not self.breakmodel:
+            return torch.float32
         return torch.float16
 
     def _apply_warpers(
@@ -268,9 +270,11 @@ class HFTorchInferenceModel(HFInferenceModel):
             gen_in = torch.tensor(prompt_tokens, dtype=torch.long)[None]
         else:
             gen_in = prompt_tokens
-
-        device = utils.get_auxilary_device()
-        gen_in = gen_in.to(device)
+        if not self.usegpu and not self.breakmodel:
+            gen_in = gen_in.to("cpu")
+        else:
+            device = utils.get_auxilary_device()
+            gen_in = gen_in.to(device)
 
         additional_bad_words_ids = [self.tokenizer.encode("\n")] if single_line else []
 

--- a/modeling/patches.py
+++ b/modeling/patches.py
@@ -190,7 +190,7 @@ def patch_transformers_for_lazyload() -> None:
             state_dict[new_key] = state_dict.pop(old_key)
 
 # BEGIN PATCH
-        utils.bar = tqdm(total=len(state_dict), desc="Loading model tensors", file=utils.UIProgressBarFile())
+        utils.bar = tqdm(total=len(state_dict), desc="Loading model tensors", file=utils.UIProgressBarFile(), position=1)
 
         for param_name, param in sorted(
             state_dict.items(),

--- a/requirements_mtj.txt
+++ b/requirements_mtj.txt
@@ -1,4 +1,4 @@
-torch >= 1.9, < 1.13
+torch == 2.0
 numpy
 tqdm
 requests


### PR DESCRIPTION
- Fixes CPU usage
- Fixes --cpu because of a new method to hide the GPU's that allows us to remove all other checks in the future
- Fixes the console bar spam

Pending:
- ROCm doesn't work since it uses an older Torch version (New one was not yet stable on ROCm)
- TPU does not work since it tries to do GPU stuff in the patchers file (Old Torch stuff but also accelerate which does not support the TPU)
- Loading in UI2 does not report progress or remaining time